### PR TITLE
fix: ping etcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ func main() {
 	s := gocron.NewScheduler(time.UTC)
 	s.WithDistributedElector(el)
 
-	s.Every("1s").Do(func() {
-		if el.IsLeader(context.TODO()) == nil {
+	_, _ = s.Every("1s").Do(func() {
+		if el.IsLeader(context.Background()) == nil {
 			fmt.Println("the current instance is leader")
 		} else {
 			fmt.Println("the current leader is", el.GetLeaderID())

--- a/elector_test.go
+++ b/elector_test.go
@@ -17,6 +17,18 @@ var (
 	testElectionPath = "/gocron/elector/"
 )
 
+func TestGocronDialTimeout(t *testing.T) {
+	start := time.Now()
+	_, err := NewElector(context.Background(), Config{
+		Endpoints: []string{"http://127.0.0.1:2000"}, // invalid etcd
+	})
+	assert.Equal(t, ErrPingEtcd, err)
+
+	// 5< 6 < 7
+	assert.Greater(t, int(time.Since(start).Seconds()), 5)
+	assert.Less(t, int(time.Since(start).Seconds()), 8)
+}
+
 func TestGocronWithElector(t *testing.T) {
 	el, err := NewElector(context.Background(), testConfig, WithTTL(1))
 	assert.Equal(t, nil, err)

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/uuid v1.3.1 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	go.uber.org/atomic v1.9.0 // indirect


### PR DESCRIPTION
### summary

If etcd server don't run, we will block on the `grant` until the etcd server can connect.

I think it can be done this way, when creating the elector, check whether etcd is available.

after add `pingEtcd`, we can fast detect etcd, if etcd is not available, return error direct. 😅

![image](https://github.com/go-co-op/gocron-etcd-elector/assets/3785409/663faabd-f6d5-4250-890b-b64d73c6ccaf)

![image](https://github.com/go-co-op/gocron-etcd-elector/assets/3785409/58cb89c9-74be-4d93-b5f0-71937caaa9e7)
