### PR TITLE
fix OOM

### DIFF
--- a/elector.go
+++ b/elector.go
@@ -189,9 +189,10 @@ func (e *Elector) Start(electionPath string) error {
 		e.unsetLeader("")
 	}()
 
+	ch := electionHandler.Observe(e.ctx)
 	for e.ctx.Err() == nil {
 		select {
-		case resp := <-electionHandler.Observe(e.ctx):
+		case resp := <-ch:
 			if len(resp.Kvs) == 0 {
 				continue
 			}


### PR DESCRIPTION
Calling electionHandler.Observe(e.ctx) within a for loop continuously creates goroutines, leading to an OOM (Out Of Memory) issue.

### What does this do?
fix OOM

### Have you included tests for your changes?
Yes