### PR TITLE
fix: handle session done

### DIFF
--- a/elector.go
+++ b/elector.go
@@ -210,6 +210,9 @@ func (e *Elector) Start(electionPath string) error {
 	ch := electionHandler.Observe(e.ctx)
 	for e.ctx.Err() == nil {
 		select {
+		case <-session.Done():
+			e.logger("session closed, attempting to restart elector")
+			return e.Start(electionPath)
 		case resp := <-ch:
 			if len(resp.Kvs) == 0 {
 				continue


### PR DESCRIPTION
### What does this do?

This fixes an issue where the Elector can be stuck in a non-functional state if its session has expired.

When the session loses its lease, such as during a network partition that exceeds the session's TTL, the election is no longer functional. In that case, we need to recreate both the session and the election. The `session.Done()` channel closes when the session is no longer being refreshed. Recalling the `Start` method will either succeed or produce an error that will bubble back up to the caller.

### Which issue(s) does this PR fix/relate to?

None.

### List any changes that modify/break current functionality

Should not change any existing functionality.

### Have you included tests for your changes?

This situation is difficult to reproduce with a single external Etcd server. My application uses an embedded Etcd server, and I run three instances of it during development. The steps I used to reproduce this issue and test the fix were:

1. Start all three servers
2. Stop two of the servers to simulate a network partition
3. Wait for the session TTL to expire
4. Start the stopped servers again

### Did you document any new/modified functionality?

N/A

### Notes
